### PR TITLE
egh_gripper_description: Fix black material color

### DIFF
--- a/egh_gripper_description/urdf/egh_gripper.urdf.xacro
+++ b/egh_gripper_description/urdf/egh_gripper.urdf.xacro
@@ -80,7 +80,7 @@
                     <mesh filename="package://egh_gripper_description/meshes/egh_finger.stl" scale="1.0 1.0 1.0"/>
                 </geometry>
                 <material name="black">
-                <color rgba="0 0 0 0"/>
+                <color rgba="0.2 0.2 0.2 1"/>
                 </material>
             </visual>
 
@@ -162,7 +162,7 @@
                     <mesh filename="package://egh_gripper_description/meshes/egh_finger.stl" scale="1.0 1.0 1.0"/>
                 </geometry>
                 <material name="black">
-                <color rgba="0 0 0 0"/>
+                <color rgba="0.2 0.2 0.2 1.0"/>
                 </material>
             </visual>
 


### PR DESCRIPTION
This commit fixes the color material. The alpha channel was 0, therefore it could not visualize in RVIZ.